### PR TITLE
Add csv converter test and fix formatting

### DIFF
--- a/csv_converter.py
+++ b/csv_converter.py
@@ -22,7 +22,7 @@ def csv_to_articles(input_file, output_directory):
                     else:
                         # Append newline after each period
                         formatted_value = value.replace(". ", ".\n")
-                        out_f.write(f"{header}:\n{value}\n\n")
+                        out_f.write(f"{header}:\n{formatted_value}\n\n")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ tornado==6.5.1
 typing_extensions==4.12.2
 tzdata==2025.1
 urllib3==2.3.0
+pytest==8.3.5

--- a/tests/test_csv_converter.py
+++ b/tests/test_csv_converter.py
@@ -1,0 +1,25 @@
+import csv
+from csv_converter import csv_to_articles
+
+
+def test_csv_to_articles(tmp_path):
+    input_csv = tmp_path / "input.csv"
+    output_dir = tmp_path / "out"
+    long_text = (
+        "This is a very long piece of text that exceeds eighty characters in total. "
+        "It contains multiple sentences. Ensure newline."
+    )
+
+    with open(input_csv, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "description", "name"])
+        writer.writerow(["1", long_text, "Test Name"])
+
+    csv_to_articles(str(input_csv), str(output_dir))
+
+    output_file = output_dir / "Test_Name.txt"
+    assert output_file.exists()
+
+    content = output_file.read_text()
+    expected = "description:\n" + long_text.replace(". ", ".\n") + "\n\n"
+    assert expected in content


### PR DESCRIPTION
## Summary
- fix `csv_to_articles` to write formatted text with newlines after each period
- add unit test covering long text newline behaviour
- ensure pytest is listed in requirements

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847abc353a08331a7912fea5883e50f