### PR TITLE
Fix README code block termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,3 @@ python `timesheet_review.py` `input/202502_ZE\ TimeSheet_OpHours.xlsx`
 - **Output folder**: After running the script, CSV files (`timesheet_entries.csv`, `time_distribution.csv`) are generated here for further analysis or uploading into the Streamlit application.
 
 ---
-```


### PR DESCRIPTION
## Summary
- remove stray backticks from the end of README

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847ae55a4b4833180745f8ab5f45955